### PR TITLE
Keep calling recv until all data is recieved.

### DIFF
--- a/stanford_corenlp_pywrapper/sockwrap.py
+++ b/stanford_corenlp_pywrapper/sockwrap.py
@@ -165,7 +165,11 @@ class SockWrap:
         # java "long" is 8 bytes, which python struct calls "long long".
         # java default byte ordering is big-endian.
         size_info = struct.unpack('>Q', size_info_str)[0]
-        data = sock.recv(size_info)
+
+        data = ""
+        while size_info - len(data) > 0:
+            data += sock.recv(size_info)
+
         return data
 
 


### PR DESCRIPTION
On my arch with some of my input files I am having trouble getting the complete data from the java server process.  This calls recv until the complete  JSON string is collected.  